### PR TITLE
fix(RaycasterHelper): hits typing

### DIFF
--- a/packages/three-raycaster-helper/src/index.ts
+++ b/packages/three-raycaster-helper/src/index.ts
@@ -3,6 +3,7 @@ import {
   BufferGeometry,
   Float32BufferAttribute,
   InstancedMesh,
+  Intersection,
   Line,
   LineBasicMaterial,
   Mesh,
@@ -17,7 +18,7 @@ const _o = new Object3D();
 const _v = new Vector3();
 export class RaycasterHelper extends Object3D {
   raycaster: Raycaster;
-  hits: [];
+  hits: Intersection[];
 
   origin: Mesh<SphereGeometry, MeshBasicMaterial>;
   near: Line<BufferGeometry, LineBasicMaterial>;


### PR DESCRIPTION
to avoid
<img width="579" alt="image" src="https://github.com/user-attachments/assets/4b7bafe0-457d-4eec-99b3-1e3f54739375" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type specificity for the `hits` property in the RaycasterHelper, allowing for better data handling of intersection results.
  
- **Bug Fixes**
	- Corrected initialization of the `hits` property to ensure it starts as an empty array of type `Intersection[]`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->